### PR TITLE
feat(add-workflow): update-closed-issues

### DIFF
--- a/.github/workflows/test-issue-on-close.yml
+++ b/.github/workflows/test-issue-on-close.yml
@@ -1,0 +1,23 @@
+name: Test Issue Close Trigger
+permissions:
+  contents: read
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print closed issue info
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          echo "Issue Number: $ISSUE_NUMBER"
+          # Prevent workflow command injection from untrusted issue titles
+          TOKEN=$(uuidgen)
+          echo "::stop-commands::${TOKEN}"
+          echo "Title: $ISSUE_TITLE"
+          echo "::${TOKEN}::"
+          echo "Workflow triggered successfully when issue was closed."

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -1,0 +1,39 @@
+name: Set Project Closed Date
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: read
+
+env:
+  PROJECT_URL: https://github.com/orgs/blinklabs-io/projects/11
+  CLOSED_DATE_FIELD: "Closed Date"
+
+jobs:
+  set-date:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve closed date
+        id: when
+        shell: bash
+        run: |
+          ts='${{ github.event.issue.closed_at }}'
+          if [ -z "$ts" ] || [ "$ts" = "null" ]; then
+            d=$(date -u +%F)
+          else
+            d=$(date -u -d "$ts" +%F)
+          fi
+          echo "date=$d" >> "$GITHUB_OUTPUT"
+          echo "Closed date -> $d"
+
+      # Update the "Closed Date" field on that project item
+      - name: Update Closed Date field
+        uses: nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b
+        with:
+          project-url: ${{ env.PROJECT_URL }}
+          github-token: ${{ secrets.ORG_PROJECT_PAT }}
+          field-name: ${{ env.CLOSED_DATE_FIELD }}
+          field-value: ${{ steps.when.outputs.date }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add two GitHub Actions that run when an issue is closed. One validates the trigger, and the other sets the “Closed Date” field on our org project.

- **New Features**
  - test-issue-on-close.yml: Prints issue number/title and blocks workflow command injection via stop-commands token.
  - update-issue-on-close.yml: Resolves closed date from event (fallback to today, UTC) and updates the “Closed Date” field on Project 11 using a pinned action and ORG_PROJECT_PAT.

- **Migration**
  - Add the ORG_PROJECT_PAT secret with Project write access.
  - Verify PROJECT_URL points to the right project and the “Closed Date” field exists.
  - Ensure closed issues are present in the project so the field update can apply.

<sup>Written for commit 54a83f6a28ac7092a15e652de471c2f96728e69c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

