### PR TITLE
chore: require Go 1.25 minimum

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v5.0.1 https://github.com/actions/checkout/releases/tag/v5.0.1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.2.0 https://github.com/actions/setup-go/releases/tag/v6.2.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v5.0.1 https://github.com/actions/checkout/releases/tag/v5.0.1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.2.0 https://github.com/actions/setup-go/releases/tag/v6.2.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
       - name: run nilaway

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/blinklabs-io/buidler-fest-2024-workshop
 
-go 1.24.0
+go 1.25.7
 
-toolchain go1.24.1
+toolchain go1.25.8
 
 require (
 	github.com/Salvionied/apollo v1.6.0


### PR DESCRIPTION
## Summary

Go 1.24 is end-of-life. This bumps the module to a **Go 1.25 minimum** and aligns CI with the rest of the Blink Labs Go repos:

- `go.mod`: `go 1.24.0` → `go 1.25.7`, `toolchain go1.24.1` → `toolchain go1.25.8`
- `go-test.yml`: test matrix `[1.24.x, 1.25.x]` → `[1.25.x, 1.26.x]`
- `golangci-lint.yml`, `nilaway.yml`: `1.25.x` → `1.26.x`

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l`, and `golangci-lint run ./...` (0 issues) all pass locally on Go 1.26. `go.sum` is unchanged.

Part of the org-wide Go 1.25 upgrade (blinklabs-io/issues#120). Scoped to the Go toolchain only; the broader dependency refresh is tracked separately in #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the minimum Go version to 1.25 and update CI to match current support. `go.mod` now targets `go 1.25.7` with `toolchain go1.25.8`; tests run on `1.25.x` and `1.26.x`, and linters run on `1.26.x`.

<sup>Written for commit 87bc01c360594a3ac2d9e0f26db329cd27039d23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/buidler-fest-2024-workshop/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

